### PR TITLE
fix: update style for multiple line of card title

### DIFF
--- a/src/components/Card/CardTitle.tsx
+++ b/src/components/Card/CardTitle.tsx
@@ -114,14 +114,14 @@ class CardTitle extends React.Component<Props> {
       style,
       title,
       titleStyle,
-      titleNumberOfLines
+      titleNumberOfLines,
     } = this.props;
 
     return (
       <View
         style={[
           styles.container,
-          { height: subtitle || left || right ? 72 : 50 },
+          { minHeight: subtitle || left || right ? 72 : 50 },
           style,
         ]}
       >
@@ -148,7 +148,10 @@ class CardTitle extends React.Component<Props> {
           ) : null}
 
           {subtitle ? (
-            <Caption style={[styles.subtitle, subtitleStyle]} numberOfLines={subtitleNumberOfLines}>
+            <Caption
+              style={[styles.subtitle, subtitleStyle]}
+              numberOfLines={subtitleNumberOfLines}
+            >
               {subtitle}
             </Caption>
           ) : null}
@@ -179,7 +182,6 @@ const styles = StyleSheet.create({
     flex: 1,
     flexDirection: 'column',
     justifyContent: 'center',
-    height: 50,
   },
 
   title: {


### PR DESCRIPTION
The title property of a card would wrap lines
The subtitle property of a card would wrap lines

### Motivation

<img width="361" alt="58108975-fb75c680-7ba9-11e9-9c36-851042827d08" src="https://user-images.githubusercontent.com/20625911/72412582-47602600-37a0-11ea-9b95-b92bf9cb39ed.png">